### PR TITLE
feat: KVログのキー先頭にアプリ名の名前空間を追加

### DIFF
--- a/logger.ts
+++ b/logger.ts
@@ -21,9 +21,13 @@ const log = async (request: Request, additionalData) => {
   const now = new Date();
   const logRecord = { ...(await logObject(now, request)), ...additionalData };
 
-  return await kv.set(["logs", now.getFullYear(), now.getMonth() + 1, now.getDate(), ulid()], logRecord, {
-    expireIn: 1000 * 60 * 60 * 24 * EXPIRE_LOGS_DAYS,
-  });
+  return await kv.set(
+    ["terminal-image", "logs", now.getFullYear(), now.getMonth() + 1, now.getDate(), ulid()],
+    logRecord,
+    {
+      expireIn: 1000 * 60 * 60 * 24 * EXPIRE_LOGS_DAYS,
+    },
+  );
 };
 
 export { log };


### PR DESCRIPTION
## 概要

KVログのキーを `["logs", year, month, day, ulid]` から `["terminal-image", "logs", year, month, day, ulid]` に変更する。

## Why

- Deno Deploy Classic終了（2026-07-20）に伴い新Deno Deployへ移行中だが、現行プランではKVデータベースを1つしか作成できないことが判明した
- そのため全アプリ（terminal-image / kusa-image / obsidian-opener）で1つのKVを共有する方針に変更し、アプリ別にログを識別・エクスポートできるようキーへアプリ名の名前空間が必要になった

## How

- `logger.ts` のキー配列の先頭に `"terminal-image"` を追加
- エクスポート側（deno-logviewer-import-dataform）は新旧両方のキー構造をprefix指定で合算取得できるようにしてあるため、本PRのマージタイミングとClassic側のトラフィック切替は独立している

## 確認観点

- [x] `deno fmt --check logger.ts` パス
- [x] `deno lint` の指摘数が変更前後で同一（既存の no-unversioned-import のみ）
- [x] `deno test` パス（3件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)