### PR TITLE
docs: 記載URLとGenerator出力URLを新Deno DeployのURLへ更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ OGP Image builder
 example
 
 ```
-https://terminal-image.deno.dev/?title=awesome_title&bottom_line_texts=tag1,tag2,tag3
+https://terminal-image.swfz.deno.net/?title=awesome_title&bottom_line_texts=tag1,tag2,tag3
 ```
 
 ### parameter
@@ -37,7 +37,7 @@ available GET url parameters
 
 If you want to create URLs or actually try things out, please use this URLGenerator.
 
-[terminal-image.deno.dev/generator](https://terminal-image.deno.dev/generator)
+[terminal-image.swfz.deno.net/generator](https://terminal-image.swfz.deno.net/generator)
 
 ## development
 

--- a/static/index.html
+++ b/static/index.html
@@ -59,7 +59,7 @@
         const topLineItemColorsParam = params.topLineItemColors.map((color) => rmSharp(color)).join(',');
         const bottomLineItemColorsParam = params.bottomLineItemColors.map((color) => rmSharp(color)).join(',');
 
-        const url = `https://terminal-image.deno.dev/?title=${params.title}
+        const url = `https://terminal-image.swfz.deno.net/?title=${params.title}
 &top_line_texts=${params.topLineTexts.join(',')}
 &bottom_line_texts=${params.bottomLineTexts.join(',')}
 &top_line_text_color=${rmSharp(params.topLineTextColor)}


### PR DESCRIPTION
## 概要

READMEの案内URLと、URL Generator（`static/index.html`）が生成するURLを新Deno DeployのURL（`terminal-image.swfz.deno.net`）へ更新する。

## Why

- Deno Deploy Classic が 2026-07-20 に終了するため新Deno Deployへ移行した
- 旧 `terminal-image.deno.dev` は終了後に到達不能になるため、案内URLとGenerator出力を新URLへ切り替える

## How

- `README.md` / `static/index.html` の `terminal-image.deno.dev` を `terminal-image.swfz.deno.net` に置換

## 確認観点

- [x] `deno fmt --check` パス
- [x] 変更は文字列のみ、描画・APIロジックへの影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)